### PR TITLE
Add catppuccin themed comments component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nabiresearch.org",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nabiresearch.org",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@astrojs/rss": "^4.0.12",
         "@astrojs/sitemap": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nabiresearch.org",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "NABI: Natural and Artificial Brain Intelligence",
   "type": "module",
   "engines": {

--- a/src/components/blog/SinglePost.astro
+++ b/src/components/blog/SinglePost.astro
@@ -4,6 +4,7 @@ import { Icon } from 'astro-icon/components';
 import Image from '~/components/common/Image.astro';
 import PostTags from '~/components/blog/Tags.astro';
 import SocialShare from '~/components/common/SocialShare.astro';
+import Comments from '~/components/widgets/Comments.astro';
 
 import { getPermalink } from '~/utils/permalinks';
 import { getFormattedDate } from '~/utils/utils';
@@ -25,7 +26,9 @@ const { post, url } = Astro.props;
         ? 'intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade'
         : 'intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade'}
     >
-      <div class="flex justify-between flex-col sm:flex-row max-w-3xl mx-auto mt-0 mb-2 px-4 sm:px-6 sm:items-center text-[15px]">
+      <div
+        class="flex justify-between flex-col sm:flex-row max-w-3xl mx-auto mt-0 mb-2 px-4 sm:px-6 sm:items-center text-[15px]"
+      >
         <p>
           <Icon name="tabler:clock" class="w-4 h-4 inline-block -mt-0.5 dark:text-gray-400" />
           <time datetime={String(post.publishDate)} class="inline-block">{getFormattedDate(post.publishDate)}</time>
@@ -104,22 +107,6 @@ const { post, url } = Astro.props;
   </article>
 
   <section class="px-4 py-14 sm:px-6 mx-auto lg:px-8 lg:py-18 max-w-4xl">
-    <div class="giscus"></div>
+    <Comments />
   </section>
 </section>
-
-<script
-  src="https://giscus.app/client.js"
-  data-repo="NABI-SNU/homepage"
-  data-repo-id="R_kgDOOkMCBQ"
-  data-category="General"
-  data-category-id="DIC_kwDOOkMCBc4CskkE"
-  data-mapping="pathname"
-  data-strict="1"
-  data-reactions-enabled="1"
-  data-emit-metadata="0"
-  data-input-position="bottom"
-  data-theme="preferred_color_scheme"
-  data-lang="en"
-  crossorigin="anonymous"
-  async></script>

--- a/src/components/common/BasicScripts.astro
+++ b/src/components/common/BasicScripts.astro
@@ -72,7 +72,7 @@ import { UI } from 'astrowind:config';
       localStorage.theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
 
       // Update theme for giscus iframe if it exists
-      const theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+      const theme = document.documentElement.classList.contains('dark') ? 'catppuccin_frappe' : 'catppuccin_latte';
       const giscusFrame = document.querySelector('iframe.giscus-frame');
 
       if (giscusFrame) {

--- a/src/components/widgets/Comments.astro
+++ b/src/components/widgets/Comments.astro
@@ -1,0 +1,28 @@
+---
+// Comments component using giscus with catppuccin themes
+const { lang = 'en' } = Astro.props;
+---
+
+<div id="giscus-container" class="giscus"></div>
+<script is:inline define:vars={{ lang }}>
+  const theme = document.documentElement.classList.contains('dark') ? 'catppuccin_frappe' : 'catppuccin_latte';
+  const attrs = {
+    src: 'https://giscus.app/client.js',
+    'data-repo': 'NABI-SNU/homepage',
+    'data-repo-id': 'R_kgDOOkMCBQ',
+    'data-category': 'General',
+    'data-category-id': 'DIC_kwDOOkMCBc4CskkE',
+    'data-mapping': 'pathname',
+    'data-strict': '1',
+    'data-reactions-enabled': '1',
+    'data-emit-metadata': '0',
+    'data-input-position': 'bottom',
+    'data-theme': theme,
+    'data-lang': lang,
+    crossorigin: 'anonymous',
+  };
+  const script = document.createElement('script');
+  Object.entries(attrs).forEach(([k, v]) => script.setAttribute(k, v));
+  script.async = true;
+  document.getElementById('giscus-container').appendChild(script);
+</script>

--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '~/layouts/PageLayout.astro';
 import SocialShare from '~/components/common/SocialShare.astro';
+import Comments from '~/components/widgets/Comments.astro';
 
 import type { MetaData } from '~/types';
 
@@ -35,22 +36,6 @@ const metadata: MetaData = {
     />
   </div>
   <section class="px-4 py-16 sm:px-6 mx-auto lg:px-8 lg:py-20 max-w-4xl">
-    <div class="giscus"></div>
+    <Comments />
   </section>
 </Layout>
-
-<script
-  src="https://giscus.app/client.js"
-  data-repo="NABI-SNU/homepage"
-  data-repo-id="R_kgDOOkMCBQ"
-  data-category="General"
-  data-category-id="DIC_kwDOOkMCBc4CskkE"
-  data-mapping="pathname"
-  data-strict="1"
-  data-reactions-enabled="1"
-  data-emit-metadata="0"
-  data-input-position="bottom"
-  data-theme="preferred_color_scheme"
-  data-lang="en"
-  crossorigin="anonymous"
-  async></script>


### PR DESCRIPTION
## Summary
- implement `Comments.astro` to load giscus with catppuccin themes
- apply component in `SinglePost` and `MarkdownLayout`
- update theme toggle script to send catppuccin theme values

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686d0d05a4c48325b58567daec9afc33